### PR TITLE
Explicitly declare nms dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,18 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+            <version>4.1.77.Final</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.mojang</groupId>
+            <artifactId>authlib</artifactId>
+            <version>1.5.25</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.github.MilkBowl</groupId>
             <artifactId>VaultAPI</artifactId>
             <version>1.7</version>
@@ -104,7 +116,7 @@
 
         <dependency>
             <groupId>org.spigotmc</groupId>
-            <artifactId>spigot</artifactId>
+            <artifactId>spigot-api</artifactId>
             <version>1.18.2-R0.1-SNAPSHOT</version>
             <!--            <classifier>remapped-mojang</classifier>-->
             <scope>provided</scope>


### PR DESCRIPTION
In order to get this project to compile on Jitpack we need to get it to compile without any locally added server jar.
Compilation still fails because of a single import in Reflection_1_17#openChestAnimation line 177:
![grafik](https://user-images.githubusercontent.com/40303883/173105528-8c8e149a-7d01-46ce-92ea-8f7c08db6d27.png)

Required for: [BetonQuest #1891](https://github.com/BetonQuest/BetonQuest/pull/1891)
